### PR TITLE
Remove signed update system entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Databox OS container manager and dashboard server.
 	cd databox-container-manager
 	npm install --production
 
+	For now the arbier IP must be in you /etc/hosts file
+
+	echo "172.17.0.2     databox-arbiter" | sudo tee -a /etc/hosts
+
 ## Usage
 	npm start
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "request": "^2.69.0",
     "should": "^11.1.1",
     "socket.io": "^1.5.0",
-    "supertest": "^2.0.1",
-    "ursa-purejs": "0.0.3"
+    "supertest": "^2.0.1"
   },
   "devDependencies": {
     "node-sass": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "promise": "^7.1.1",
     "pug": "^2.0.0-beta6",
     "request": "^2.69.0",
+    "selfsigned": "^1.8.0",
     "should": "^11.1.1",
     "socket.io": "^1.5.0",
     "supertest": "^2.0.1",

--- a/src/config.json
+++ b/src/config.json
@@ -2,7 +2,7 @@
 {
 	"registryUrl": "registry.iotdatabox.com",
   	"storeUrl": "https://store.iotdatabox.com",
-	"registryUrl_dev": "amar.io:5000",
+	"registryUrl_dev": "databox.amar.io",
 	"storeUrl_dev": "https://datashop.amar.io",
   	"serverPort": 8080
 }

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -337,43 +337,6 @@ exports.launchArbiter = function () {
 	});
 };
 
-var directoryName = null;
-var DATABOX_DIRECTORY_ENDPOINT = null;
-var DATABOX_DIRECTORY_PORT = 3000;
-exports.launchDirectory = function () {
-	return new Promise((resolve, reject) => {
-		var name = "databox-directory" + ARCH;
-		directoryName = name;
-		pullImage(name + ":latest")
-			.then(() => {
-				return dockerHelper.createContainer(
-					{
-						'name': name,
-						'Image': Config.registryUrl + "/" + name + ":latest",
-						'PublishAllPorts': true
-					}
-				);
-			})
-			.then((directory) => {
-				return startContainer(directory);
-			})
-			.then((directory) => {
-				return dockerHelper.connectToNetwork(directory, 'databox-driver-net');
-			})
-			.then((directory) => {
-				return dockerHelper.connectToNetwork(directory, 'databox-app-net');
-			})
-			.then((directory) => {
-				DATABOX_DIRECTORY_ENDPOINT = 'http://' + directory.ip + ':' + DATABOX_DIRECTORY_PORT + '/api';
-				resolve(directory);
-			})
-			.catch((err) => {
-				console.log("Error creating Directory");
-				reject(err);
-			});
-
-	});
-};
 
 var notificationsName = null;
 var DATABOX_NOTIFICATIONS_ENDPOINT = null;
@@ -381,7 +344,6 @@ var DATABOX_NOTIFICATIONS_PORT = 8080;
 exports.launchNotifications = function () {
 	return new Promise((resolve, reject) => {
 		var name = "databox-notifications" + ARCH;
-		directoryName = name;
 		pullImage(name + ":latest")
 			.then(() => {
 				return dockerHelper.createContainer(
@@ -553,13 +515,12 @@ var launchContainer = function (containerSLA) {
 		'Env': [
 			"DATABOX_IP=" + ip,
 			"DATABOX_LOCAL_NAME=" + containerSLA.localContainerName,
-			"DATABOX_DIRECTORY_ENDPOINT=" + DATABOX_DIRECTORY_ENDPOINT,
-			"DATABOX_ARBITER_ENDPOINT=" + DATABOX_ARBITER_ENDPOINT,
-			"DATABOX_NOTIFICATIONS_ENDPOINT=" + DATABOX_NOTIFICATIONS_ENDPOINT
+			"DATABOX_ARBITER_ENDPOINT=" + DATABOX_ARBITER_ENDPOINT
+			//"DATABOX_NOTIFICATIONS_ENDPOINT=" + DATABOX_NOTIFICATIONS_ENDPOINT
 		],
 		'PublishAllPorts': true,
 		'NetworkingConfig': {
-			'Links': [directoryName, arbiterName]
+			'Links': [arbiterName]
 		}
 	};
 	var launched = [];

--- a/src/include/containter-manger-https-helper.js
+++ b/src/include/containter-manger-https-helper.js
@@ -1,0 +1,74 @@
+var selfsigned = require('selfsigned');
+var forge = require('node-forge');
+
+
+var attrs = [{ name: 'commonName', value: 'databox' }];
+var config = { days: 365, keySize: 2048, days: 3650, algorithm: 'sha256' };
+var rootPems;
+
+//Generate the CM root cert at startup
+var init = function() {
+    return new Promise( (resolve, reject) =>  {
+        selfsigned.generate(attrs, config, function (err, pems) {
+            if(err) {
+                reject(err);
+            }
+            rootPems = pems;
+            resolve({rootCAcert:rootPems.cert});
+        });
+    });
+};
+
+var getRootCert =  function () {
+    return rootPems.cert;
+};
+
+//based on code extracted from the selfsigned module Licence MIT 
+var createClientCert =  function (commonName) {
+    
+    function toPositiveHex(hexString){
+    var mostSiginficativeHexAsInt = parseInt(hexString[0], 16);
+    if (mostSiginficativeHexAsInt < 8){
+        return hexString;
+    }
+
+    mostSiginficativeHexAsInt -= 8;
+    return mostSiginficativeHexAsInt.toString() + hexString.substring(1);
+    }
+    
+    return new Promise( (resolve, reject) =>  {
+
+    var pki = forge.pki;
+    pem = {};
+
+    var clientkeys = forge.pki.rsa.generateKeyPair(2048);
+    var clientcert = forge.pki.createCertificate();
+    clientcert.serialNumber = toPositiveHex(forge.util.bytesToHex(forge.random.getBytesSync(9)));
+    clientcert.validity.notBefore = new Date();
+    clientcert.validity.notAfter = new Date();
+    clientcert.validity.notAfter.setFullYear(clientcert.validity.notBefore.getFullYear() + 10);
+
+    var clientAttrs = [{ name: 'commonName', value: commonName }];
+
+    clientcert.setSubject(clientAttrs);
+    // Set the issuer to the parent key
+    clientcert.setIssuer(attrs);
+
+    clientcert.publicKey = clientkeys.publicKey;
+
+    // Sign client cert with root cert
+    try {
+        rootPrivateKey = pki.privateKeyFromPem(rootPems.private);
+        clientcert.sign(rootPrivateKey);
+    } catch (e) {
+        reject("ERROR",e);
+    }
+    pem.clientprivate = forge.pki.privateKeyToPem(clientkeys.privateKey);
+    pem.clientpublic = forge.pki.publicKeyToPem(clientkeys.publicKey);
+    pem.clientcert = forge.pki.certificateToPem(clientcert);
+
+    resolve(pem);
+    });
+};
+
+module.exports = {init:init, createClientCert:createClientCert, getRootCert:getRootCert};

--- a/src/main.js
+++ b/src/main.js
@@ -23,13 +23,6 @@ httpsHelper.init()
 		console.log('[databox-arbiter] Launching');
 		return conman.launchArbiter(httpsHelper);
 	})
-
-	.then(info => {
-		server.proxies[info.name] = 'localhost:' + info.port;
-
-		console.log('[databox-directory] Launching');
-		return conman.launchDirectory(httpsHelper);
-	})
 	
 	/*.then(info => {
 		server.proxies[info.name] = 'localhost:' + info.port;

--- a/src/main.js
+++ b/src/main.js
@@ -31,12 +31,12 @@ httpsHelper.init()
 		return conman.launchDirectory(httpsHelper);
 	})
 	
-	.then(info => {
+	/*.then(info => {
 		server.proxies[info.name] = 'localhost:' + info.port;
 
 		console.log('[databox-notification] Launching');
 		return conman.launchNotifications(httpsHelper);
-	})
+	})*/
 	.then(info => {
 		server.proxies[info.name] = 'localhost:' + info.port;
 


### PR DESCRIPTION
The point of assymetric crypto was for the CM to be able to prove authorship to the arbiter by signing updates. This commit makes the CM instead use the key/token system that everything else uses. The key is passed to the arbiter as an environment variable just as it is for other containers. Since we use HTTPS for all connections to the arbiter, the keys are protected as they are passed with requests. Resolves #11.

Code and docs in Hypercat branch in arbiter will be updated to reflect this.