### PR TITLE
Cm proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,4 @@ node_modules
 #sla db
 sladatastore.db
 certs/*
-updateLocalRegistery.sh
+updateLocalRegistry.sh

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ To update your hosts file with arbiter and registry IP, run the following with r
 
 ## Usage
 
-In production mode (remote docker registery and remote app store)
+In production mode (remote docker registry and remote app store)
 
 	npm start
 
-In development (local docker registery and local App store)
+In development (local docker registry and local App store)
 
     DATABOX_DEV=1 npm start  
 	Note: in dev mode some extra configuration is required. Follow the on screen instructions.   

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "mocha": "^3.1.2",
     "nedb": "^1.8.0",
     "node-forge": "^0.6.45",
-    "promise": "^7.1.1",
     "pug": "^2.0.0-beta6",
     "request": "^2.69.0",
     "selfsigned": "^1.8.0",

--- a/src/config.json
+++ b/src/config.json
@@ -8,5 +8,10 @@
 	"localRegistryName":"databox-local-registry",
 	"localRegistryImage":"toshdatabox/databox-local-registry",
 	"localAppStoreName":"databox-app-server",
-	"localRegistrySeedImages": ["databox-arbiter","databox-app-server","databox-store-blob","databox-driver-twitter-stream"]
+	"localRegistrySeedImages": ["databox-arbiter","databox-app-server","databox-store-blob","databox-driver-twitter-stream","databox-app-twitter-sentiment"],
+	"localAppStoreSeedManifests": [
+									"https://raw.githubusercontent.com/me-box/databox-driver-twitter-stream/Hypercat/databox-manifest.json",
+									"https://raw.githubusercontent.com/me-box/databox-store-blob/Hypercat/databox-manifest.json",
+									"https://raw.githubusercontent.com/Toshbrown/databox-app-twitter-sentiment/master/databox-manifest.json"
+								  ]
 }

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -382,7 +382,7 @@ exports.launchArbiter = function () {
 						console.log("[databox-arbiter] Launched");
 						DATABOX_ARBITER_ENDPOINT = 'https://' + Arbiter.name + ':' + DATABOX_ARBITER_PORT;
 						DATABOX_ARBITER_ENDPOINT_IP = 'https://' + Arbiter.ip + ':' + DATABOX_ARBITER_PORT;
-						resolve({'name': Arbiter.name, port: Arbiter.port});
+						resolve({'name': Arbiter.name, 'port': Arbiter.port, 'CM_KEY': arbiterKey, });
 					}
 					else {
 						setTimeout(() => {

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -1,6 +1,5 @@
 /*jshint esversion: 6 */
 
-var Promise = require('promise');
 var Config = require('./config.json');
 var os = require('os');
 var crypto = require('crypto');
@@ -557,8 +556,8 @@ var launchDependencies = function (containerSLA) {
 								return launchContainer(sla);
 							}
 						})
-						.then((infos)=> {
-							resolve(infos);
+						.then((info)=> {
+							resolve(info);
 						})
 						.catch((err) => {
 							//install failed Give up :-(
@@ -568,7 +567,7 @@ var launchDependencies = function (containerSLA) {
 				});
 		}));
 	}
-	return new Promise.all(promises);
+	return Promise.all(promises);
 };
 
 var launchContainer = function (containerSLA) {

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -280,7 +280,7 @@ exports.launchLocalAppStore = function() {
 			})
 			.then(() => {
 				console.log("waiting for local app store ....");
-				setTimeout(resolve,2000);
+				setTimeout(resolve,3000);
 			})
 			.catch((error)=>{
 				console.log("[launchLocalAppStore]",error);

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -328,7 +328,6 @@ exports.launchLocalRegistry = function() {
 
 var arbiterName = '';
 var arbiterKey = null;
-exports.arbiterKey = arbiterKey;
 var DATABOX_ARBITER_ENDPOINT = null;
 var DATABOX_ARBITER_ENDPOINT_IP = null;
 var DATABOX_ARBITER_PORT = '8080';

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -213,7 +213,7 @@ exports.stopContainer = function (cont) {
 				return;
 			}
 			resolve(cont);
-		})
+		});
 	});
 };
 
@@ -308,7 +308,7 @@ exports.launchLocalRegistry = function() {
 				setTimeout(resolve,2000);
 			})
 			.catch((error)=>{
-				console.log("[]");
+				console.log("[launchLocalRegistry]",error);
 				reject(error);
 			});
 	});
@@ -384,8 +384,8 @@ exports.launchArbiter = function () {
 				if(DATABOX_DEV) {
 					console.log(
 						"\n#################### Error creating Arbiter ######################\n\n" +
-						"Have you seeded the local docker registery with the arbiter and demo images ? try running \n"+
-						"\n \t sh ./updateLocalRegistery.sh \n" +
+						"Have you seeded the local docker registry with the arbiter and demo images ? try running \n"+
+						"\n \t sh ./updateLocalRegistry.sh \n" +
 						"#################### Error creating Arbiter ######################\n\n"
 					);
 				}

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -125,56 +125,45 @@ exports.initNetworks = function () {
 		.catch(err => reject(err));
 };
 
+//Pull latest image from any repo defaults to dockerIO
 var pullDockerIOImage = function (imageName) {
 	return new Promise((resolve, reject) => {
-		//Pull latest Arbiter image
 		var parts = imageName.split(':');
 		var name = parts[0];
 		var version = parts[1];
 		console.log('[' + name + '] Pulling ' + version + ' image');
-		docker.pull( imageName, (err, stream) => {
-			if (err) {
-				reject(err);
-				return;
-			}
-
-			stream.pipe(process.stdout);
-			docker.modem.followProgress(stream, (err, output) => {
-				if (err) {
-					reject(err);
-					return;
-				}
-				resolve(";->");
-			});
-		});
+		dockerImagePull(imageName, resolve,reject);
 	});
 };
 
+//Pull latest image from Config.registryUrl
 var pullImage = function (imageName) {
 	return new Promise((resolve, reject) => {
-		//Pull latest Arbiter image
 		var parts = imageName.split(':');
 		var name = parts[0];
 		var version = parts[1];
 		console.log('[' + name + '] Pulling ' + version + ' image');
-		docker.pull(Config.registryUrl + "/" + imageName, (err, stream) => {
-			if (err) {
-				reject(err);
-				return;
-			}
-
-			stream.pipe(process.stdout);
-			docker.modem.followProgress(stream, (err, output) => {
-				if (err) {
-					reject(err);
-					return;
-				}
-				resolve(";->");
-			});
-		});
+		dockerImagePull(Config.registryUrl + "/" + imageName, resolve,reject);
 	});
 };
 exports.pullImage = pullImage;
+
+var dockerImagePull = function (image,resolve,reject) {
+	docker.pull(image, (err, stream) => {
+			if (err) {
+				reject(err);
+				return;
+			}
+			stream.pipe(process.stdout);
+			docker.modem.followProgress(stream, (err, output) => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				resolve(";->");
+			});
+		});
+};
 
 var getContainerInfo = function (container) {
 	return dockerHelper.inspectContainer(container)
@@ -315,7 +304,7 @@ exports.launchLocalRegistry = function() {
 				return startContainer(Reg);
 			})
 			.then(() => {
-				console.log("waiting for local registery ....");
+				console.log("waiting for local register ....");
 				setTimeout(resolve,2000);
 			})
 			.catch((error)=>{

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -328,6 +328,7 @@ exports.launchLocalRegistry = function() {
 
 var arbiterName = '';
 var arbiterKey = null;
+exports.arbiterKey = arbiterKey;
 var DATABOX_ARBITER_ENDPOINT = null;
 var DATABOX_ARBITER_ENDPOINT_IP = null;
 var DATABOX_ARBITER_PORT = '8080';

--- a/src/include/container-manager-db.js
+++ b/src/include/container-manager-db.js
@@ -1,4 +1,4 @@
-var Promise = require('promise');
+/*jshint esversion: 6 */
 
 //local storage of SLA 
 var Datastore = require('nedb');

--- a/src/include/container-manager-docker-helper.js
+++ b/src/include/container-manager-docker-helper.js
@@ -1,3 +1,5 @@
+/*jshint esversion: 6 */
+
 var Docker = require('dockerode');
 var DockerEvents = require('docker-events');
 

--- a/src/include/containter-manger-https-helper.js
+++ b/src/include/containter-manger-https-helper.js
@@ -16,14 +16,14 @@ const devCAPath = './certs/containerManager.crt';
 
 //Generate the CM root cert at startup.
 //If in DEV mode we need to use the same certs at restart because the docker demon has to trust the container manger CA to verify 
-//the local registery. If we are not in dev mode then the certs are generated at each restart of the container manger.
+//the local registry. If we are not in dev mode then the certs are generated at each restart of the container manger.
 var init = function() {
     return new Promise( (resolve, reject) =>  {
 
         
         jsonfile.readFile(devCertPath, function (err, obj) {
             
-            //return cached certs if we have then and are in DEV mode
+            //return cached certs if we have them and are in DEV mode
             if(err === null && DATABOX_DEV) {
                 rootPems = obj;
                 resolve({rootCAcert:rootPems.cert});
@@ -58,8 +58,8 @@ var init = function() {
                         "\n \t MAC OSX:: use the gui! \n"+
                         "Then restart the container manager:\n"+
                         "\n \t DATABOX_DEV=1 npm start \n"+
-                        "Then seed the local docker registery with the demo images:\n"+
-                        "\n \t sh ./updateLocalRegistery.sh \n"+
+                        "Then seed the local docker registry with the demo images:\n"+
+                        "\n \t sh ./updateLocalRegistry.sh \n"+
                         "\n#################### END INSTALL INSTRUCTIONS #####################\n"
                     );
                 }

--- a/src/lib/databox-datasource-helper.js
+++ b/src/lib/databox-datasource-helper.js
@@ -1,0 +1,217 @@
+
+var databoxRequest = require('./databox-request.js');
+//var request = require('request');
+const WebSocketClient = require('ws');
+const httpsAgent = require('./databox-https-agent.js');
+const macaroonCache = require('./databox-macaroon-cache.js');
+const url = require('url');
+
+
+
+/**
+ * Register an actuator with a datastore, subscribe for live updates and register callback 
+ * 
+ * @param {string} storeEndPoint The datastore uri
+ * @param {string} driverName The name of the driver registering the datasource 
+ * @param {string} actuatorName The name of the actuator (must be unique within a driver datastore pair)
+ * @param {string} type The urn:X-databox:rels:sensortype
+ * @param {string} unit The measurements unit if applicable 
+ * @param {string} description Human readable description
+ * @param {string} location A location for the device as a human readable string 
+ * @param {function} onDataCallback A function to callback when new data is available i.e where their is a request for actuation.
+ * @returns
+ */
+module.exports.registerActuator = function (storeEndPoint, driverName, actuatorName, type, unit, description, location, onDataCallback) {
+  
+  return new Promise((resolve, reject) => {
+  
+    register(storeEndPoint, driverName, actuatorName, type, unit, description, location, true)
+    .then(()=>{
+      //connect to ws
+      return openWS(storeEndPoint);
+    })
+    .then(() => {
+      
+      //register callback
+      wsCallbacks[actuatorName] = onDataCallback;
+      
+      //SUB for data
+      var options = {
+        uri: storeEndPoint+'/sub/'+actuatorName,
+        method: "GET"
+      };
+      console.log("[WS] trying to subscribe for updates.", options);
+      databoxRequest(options,(error,response,data)=>{
+        if (error) {
+          console.log("[ERROR] Can not register actuator subscription with datastore!", error);
+          reject(error);
+          return;
+        } else if(response && response.statusCode != 200) {
+          console.log("[ERROR] Can not register actuator subscription with datastore!", body);
+          reject(body);
+          return;
+        }
+        console.log("[WS] subscribed for updates for " + actuatorName);
+        resolve();
+      });
+    })
+    .catch((err)=>{
+      reject(err);
+    }) ;
+  
+  });
+
+};
+
+/**
+ * Register a  datasource with a datastore  
+ * 
+ * @param {string} storeEndPoint The datastore uri
+ * @param {string} driverName The name of the driver registering the datasource 
+ * @param {string} datasourceName The name of the datasource (must be unique within a driver datastore pair)
+ * @param {string} type The urn:X-databox:rels:sensortype
+ * @param {string} unit The measurements unit if applicable 
+ * @param {string} description Human readable description
+ * @param {string} location A location for the device as a human readable string 
+ * @param {function} onDataCallback A function to callback when new data is available.
+ * @returns
+ */
+module.exports.registerDatasource = function (storeEndPoint, driverName, datasourceName, type, unit, description, location) {
+  return register(storeEndPoint, driverName, datasourceName, type, unit, description, location, false);
+};
+
+
+/**
+ *  internal function to register a  datasource or actuator with a datastore
+ * 
+ * @param {string} storeEndPoint The datastore uri
+ * @param {string} driverName The name of the driver registering the datasource 
+ * @param {string} datasourceName The name of the datasource (must be unique within a driver datastore pair)
+ * @param {string} type The urn:X-databox:rels:sensortype
+ * @param {string} unit The measurements unit if applicable 
+ * @param {string} description Human readable description
+ * @param {string} location A location for the device as a human readable string 
+ * @param {bool} isActuator is this an actuator?
+ * @returns
+ */
+register = function (storeEndPoint, driverName, datasourceName, type, unit, description, location, isActuator) {
+  var options = {
+        uri: storeEndPoint+'/cat/add/'+datasourceName,
+        method: 'POST',
+        json: 
+        {
+          "vendor": driverName,
+          "sensor_type": type,
+          "unit": unit,
+          "description": description,
+          "location": location,
+          "isActuator": isActuator,
+        },
+    };
+
+  return new Promise((resolve, reject) => {
+    
+    var register_datasource_callback = function (error, response, body) {
+        if (error) {
+          console.log("[ERROR] Can not register with datastore! waiting 5s before retrying", error);
+          setTimeout(databoxRequest, 5000, options, register_datasource_callback);
+          return;
+        } else if(response && response.statusCode != 200) {
+          console.log("[ERROR] Can not register with datastore! waiting 5s before retrying", body, error);
+          setTimeout(databoxRequest, 5000, options, register_datasource_callback);
+          return;
+        }
+        resolve(body);
+    };
+    console.log("Trying to register with datastore.", options);
+    databoxRequest(options,register_datasource_callback);
+  
+  });
+};
+
+/**
+ * Waits for a datastore to become active by checking its /status endpoint
+ * 
+ * @param {string} storeEndPoint uri of the datastore to connect to
+ * @returns Promise
+ */
+module.exports.waitForDatastore = function (storeEndPoint) {
+  return new Promise((resolve, reject)=>{
+    var untilActive = function (error, response, body) {
+      if(error) {
+        console.log(error);
+      } else if(response && response.statusCode != 200) {
+        console.log("Error::", body);
+      }
+      if (body === 'active') {
+        resolve();
+      }
+      else {
+        var options = {
+              uri: storeEndPoint + "/status",
+              method: 'GET',
+              agent: httpsAgent
+          };
+        setTimeout(() => {
+          databoxRequest(options, untilActive);
+        }, 1000);
+        console.log("Waiting for datastore ....", error, body,options);
+      }
+    };
+    untilActive({});
+  });
+};
+
+
+/*
+* Web sockets to handle actuator monitoring 
+*/
+var ws = null; 
+var wsCallbacks = {};
+
+/**
+ * Open a WebSocket to the datastore if one dose not exist.
+ * 
+ * @param {string} storeEndPoint uri of the datastore to connect to
+ * @returns Promise
+ * 
+ * TODO: This will not handle multiple datastores! 
+ */
+function openWS(storeEndPoint) {
+  return new Promise((resolve, reject) => {
+    
+    if(ws === null) {
+     
+      var wsEndPoint = storeEndPoint+'/ws';
+
+      var urlObject = url.parse(wsEndPoint);
+      var path = urlObject.pathname;
+      var host = urlObject.hostname;
+
+      console.log("[WS] trying to open WS at" + wsEndPoint);
+      macaroonCache.getMacaroon(host)
+      .then((macaroon)=>{
+        ws = new WebSocketClient(wsEndPoint,{'agent':httpsAgent, headers: {'X-Api-Key': macaroon}});
+        ws.on('open', function open() {
+          console.log("[WS] for actuator callbacks opened");
+          resolve();
+        });
+      
+        ws.on('message', function(data, flags) {
+            console.log("[WS] data received",data, flags);
+        });
+
+        ws.on('error', function(data, flags) {
+            console.log("[WS] ERROR",data, flags);
+        });
+
+      })
+      .catch((error)=>{
+        console.log("[WS] ERROR");
+        reject(error);
+      });
+    } else {
+      resolve();
+    }
+  });
+}

--- a/src/lib/databox-https-agent.js
+++ b/src/lib/databox-https-agent.js
@@ -1,0 +1,22 @@
+
+const https = require('https');
+
+//
+//Databox ENV vars
+//
+const CM_HTTPS_CA_ROOT_CERT = process.env.CM_HTTPS_CA_ROOT_CERT || '';
+
+//
+// An https.Agent to trust the CM https cert if one is provided
+//
+var agentOptions = {};
+if(CM_HTTPS_CA_ROOT_CERT === '') {
+    console.log("WARNING[databox-request]:: no https root cert provided not checking https certs.");
+    agentOptions.rejectUnauthorized = false;
+} else {
+    agentOptions.ca = CM_HTTPS_CA_ROOT_CERT;
+}
+
+var httpsAgent = new https.Agent(agentOptions);
+
+module.exports = httpsAgent;

--- a/src/lib/databox-macaroon-cache.js
+++ b/src/lib/databox-macaroon-cache.js
@@ -1,0 +1,72 @@
+
+const request = require('request');
+const httpsAgent = require('./databox-https-agent.js');
+
+
+const DATABOX_ARBITER_ENDPOINT = process.env.DATABOX_ARBITER_ENDPOINT || "https://databox-arbiter:8080";
+const ARBITER_TOKEN   = process.env.ARBITER_TOKEN;
+
+var macaroonCache = {};
+
+/**
+ * Gets a macaroon form the cache if one exists else it requests one from the arbiter. 
+ *
+ * @param {host} The host name of the end point to request the macaroon
+ * @return {Promise} A promise that resolves with a shared secret gotten from the arbiter
+ * 
+ */
+function getMacaroon(host) {
+    return new Promise((resolve, reject) => {
+
+        if(macaroonCache[host]) {
+            console.log("[macaroonCache] returning cashed macaroon");
+            //TODO check if the macaroon has expired? for now if a request fails we invalidate the macaroon
+            resolve(macaroonCache[host]);
+            return;
+        }
+
+        //
+        // Macroon has not been requested. Get a new one.
+        //
+        console.log("[macaroonCache] cashed macaroon not found for " + host + " requesting one");
+        var opts = {
+                uri: DATABOX_ARBITER_ENDPOINT+'/token',
+                method: 'POST',
+                form: {
+                            target: host,
+                        },
+                headers: {'X-Api-Key': ARBITER_TOKEN},
+                agent: httpsAgent
+            };
+        
+        request(opts,function (error, response, body) {
+            if(error !== null) {
+                console.log("[macaroonCache] Request Error:: ", error);
+                reject(error);
+                return;
+            } else if (response.statusCode != 200) {
+                console.log("[macaroonCache] API Error:: ", body);
+                //API responded with an error
+                reject(body);
+                return;
+            }
+            macaroonCache[host] = body;
+            console.log("[macaroonCache] returning new macaroon");
+            resolve(macaroonCache[host]);
+        });
+    });
+}
+
+/**
+ * Gets a macaroon form the cache if one exists else it requests one from the arbiter. 
+ * @param {host} The host name of the end point to request the macaroon
+ * @return void
+ */
+function invalidateMacaroon(host) {
+    macaroonCache[host] = null;
+}
+
+module.exports = {
+    'getMacaroon':getMacaroon,
+    'invalidateMacaroon':invalidateMacaroon
+};

--- a/src/lib/databox-request-promise.js
+++ b/src/lib/databox-request-promise.js
@@ -1,0 +1,70 @@
+
+const request = require('request');
+const url = require('url');
+const httpsAgent = require('./databox-https-agent.js');
+const macaroonCache = require('./databox-macaroon-cache.js');
+
+//
+//Databox ENV vars
+//
+const DATABOX_ARBITER_ENDPOINT = process.env.DATABOX_ARBITER_ENDPOINT || "https://databox-arbiter:8080";
+const ARBITER_TOKEN = process.env.ARBITER_TOKEN || '';
+/**
+ * This module wraps the node request module https://github.com/request/request and adds:
+ * 
+ * 1) an https agetnt that trust the container manger CA
+ * 2) appropriate arbiter token when communicating with the arbiter
+ * 3) Requests and caches macaroon form the arbiter before communicating with databox components other then the arbiter.
+ *   
+ * @param {object} options a request option object (The only required option is uri) 
+ * @param {function} callback a call back on completion. The callback argument gets 3 arguments error, response, body 
+ */
+module.exports = function (options,callback) {
+    return new Promise((resolve,reject)=>{
+        //use the databox https agent
+        options.agent = httpsAgent;
+
+        //
+        // Workout the host and path of the request
+        //
+        var urlObject = url.parse(options.uri);
+        var path = urlObject.pathname;
+        var host = urlObject.hostname;
+        
+        //request to arbiter do not need a macaroon but do need the ARBITER_TOKEN
+        var isRequestToArbiter = DATABOX_ARBITER_ENDPOINT.indexOf(host) !== -1;
+        if(isRequestToArbiter) {
+            options.headers = {'X-Api-Key': ARBITER_TOKEN};
+            //do the request and call back when done
+            console.log("[databox-request] " + options.uri);
+            resolve(request(options,callback));
+        } else {
+            //
+            // we are talking to another databox component so we need a macaroon!
+            //
+            macaroonCache.getMacaroon(host)
+            .then((macaroon)=>{
+                //do the request and call back when done
+                options.headers = {'X-Api-Key': macaroon};
+                console.log("[databox-request-with-macaroon] ", options.uri);
+                resolve(request(options,callback));
+            })
+            .catch((result)=>{
+                if(result.error !== null) {
+                    console.log(result.error);
+                    reject(result.error,result.response,null);
+                    macaroonCache.invalidateMacaroon(host);
+                    return;
+                } else if (result.response.statusCode != 200) {
+                    //API responded with an error
+                    console.log(result.body);
+                    reject(result.body,result.response,null);
+                    macaroonCache.invalidateMacaroon(host);
+                    return;
+                } else {
+                    console.log(result.body, result.error);
+                }
+            });
+        }
+    });
+};

--- a/src/lib/databox-request.js
+++ b/src/lib/databox-request.js
@@ -1,0 +1,67 @@
+
+const request = require('request');
+const url = require('url');
+const httpsAgent = require('./databox-https-agent.js');
+const macaroonCache = require('./databox-macaroon-cache.js');
+
+//
+//Databox ENV vars
+//
+const DATABOX_ARBITER_ENDPOINT = process.env.DATABOX_ARBITER_ENDPOINT || "https://databox-arbiter:8080";
+
+/**
+ * This module wraps the node request module https://github.com/request/request and adds:
+ * 
+ * 1) an https agetnt that trust the container manger CA
+ * 2) appropriate arbiter token when communicating with the arbiter
+ * 3) Requests and caches macaroon form the arbiter before communicating with databox components other then the arbiter.
+ *   
+ * @param {object} options a request option object (The only required option is uri) 
+ * @param {function} callback a call back on completion. The callback argument gets 3 arguments error, response, body 
+ */
+module.exports = function (options,callback) {
+
+  //use the databox https agent
+  options.agent = httpsAgent;
+
+  //
+  // Workout the host and path of the request
+  //
+  var urlObject = url.parse(options.uri);
+  var path = urlObject.pathname;
+  var host = urlObject.hostname;
+  
+  //request to arbiter do not need a macaroon but do need the ARBITER_TOKEN
+  var isRequestToArbiter = DATABOX_ARBITER_ENDPOINT.indexOf(host) !== -1;
+  if(isRequestToArbiter) {
+      options.headers = {'X-Api-Key': ARBITER_TOKEN};
+      //do the request and call back when done
+      console.log("[databox-request] " + options.uri);
+      return request(options,callback);
+  } else {
+      //
+      // we are talking to another databox component so we need a macaroon!
+      //
+      macaroonCache.getMacaroon(host)
+      .then((macaroon)=>{
+          //do the request and call back when done
+          options.headers = {'X-Api-Key': macaroon};
+          console.log("[databox-request-with-macaroon] ", options.uri, options.headers);
+          return request(options,callback);
+      })
+      .catch((result)=>{
+          if(result.error !== null) {
+              callback(result.error,result.response,null);
+              macaroonCache.invalidateMacaroon(host);
+              return;
+          } else if (result.response.statusCode != 200) {
+              //API responded with an error
+              callback(result.body,result.response,null);
+              macaroonCache.invalidateMacaroon(host);
+              return;
+          }
+      });
+      
+  }
+
+};

--- a/src/main.js
+++ b/src/main.js
@@ -2,14 +2,18 @@
 
 var conman = require('./container-manager.js');
 var Config = require('./config.json');
-var server = require('./server.js');
 var fs = require('fs');
 var httpsHelper = require('./include/containter-manger-https-helper');
-
 var DATABOX_DEV = process.env.DATABOX_DEV
+
+var containerMangerUIServer = null;
 
 httpsHelper.init()
 	.then(cert => {
+		
+		//Put the CA pubic key into this processes env var so lib that work in containers also work in the CM
+		process.env['CM_HTTPS_CA_ROOT_CERT'] = httpsHelper.getRootCert();
+
 		conman.setHttpsHelper(httpsHelper);
 		return conman.connect();
 	})
@@ -45,10 +49,21 @@ httpsHelper.init()
 	})
 	
 	.then(info => {
-		server.proxies[info.name] = info.name + ':' + info.port;
 
+		//set env vars in this process so lib that work in containers also work in the CM 
+		process.env['DATABOX_ARBITER_ENDPOINT'] = 'https://' + info.name + ':' + info.port;
+		process.env['ARBITER_TOKEN'] = info.CM_KEY;
+		process.env['CM_KEY'] = info.CM_KEY;
+
+		//require here so env vars are set!
+		containerMangerUIServer = require('./server.js');
+
+		//set up the arbitor proxy
+		containerMangerUIServer.proxies[info.name] = info.name + ':' + info.port;
+		
+		//start the CM UI
 		console.log("Starting UI Server!!");
-		return server.launch(Config.serverPort, conman, httpsHelper);
+		return containerMangerUIServer.launch(Config.serverPort, conman, httpsHelper);
 	})
 	
 	.then(() => {
@@ -60,7 +75,7 @@ httpsHelper.init()
 	})
 
 	/*.then(info => {
-		server.proxies[info.name] = container.name+':' + info.port;
+		containerMangerUIServer.proxies[info.name] = container.name+':' + info.port;
 
 		console.log('[databox-notification] Launching');
 		return conman.launchNotifications(httpsHelper);
@@ -76,12 +91,18 @@ httpsHelper.init()
 		console.log(infos);
 		for (var containers of infos) {
 			for (var container of containers) {
-				server.proxies[container.name] = container.name+':' + container.port;
+				containerMangerUIServer.proxies[container.name] = container.name+':' + container.port;
 			}
 		}
 
 		console.log("--------- Done launching saved containers ----------");
 		console.log("Databox UI can be accessed at http://127.0.0.1:"+Config.serverPort);
+	})
+	.then(()=>{
+
+		var app = containerMangerUIServer.app;
+		module.exports = app;
+
 	})
 	.catch(err => {
 		console.log(err);
@@ -89,5 +110,3 @@ httpsHelper.init()
 		console.log(stack);
 	});
 
-var app = server.app;
-module.exports = app;

--- a/src/main.js
+++ b/src/main.js
@@ -28,7 +28,7 @@ httpsHelper.init()
 
 	.then(() => {
 		if(DATABOX_DEV) {
-			const devSeedScript = './updateLocalRegistery.sh';
+			const devSeedScript = './updateLocalRegistry.sh';
 			console.log('['+Config.localRegistryName+'] updating ' + devSeedScript);
 			var script = "";
 			for(img of Config.localRegistrySeedImages) {
@@ -88,14 +88,13 @@ httpsHelper.init()
 							if(error) {
 								console.log("[seeding manifest] Failed to POST manifest " + url, error);
 							} else {
-								console.log("[seeding manifest]" + url + " SUCCESS ", error);
+								console.log("[seeding manifest]" + url + " SUCCESS ");
 								resolve();
 							}
 						});
 					});
 				});
 			});
-			console.log(proms);
 			return Promise.all(proms);
 		}
 	})

--- a/src/main.js
+++ b/src/main.js
@@ -74,28 +74,34 @@ httpsHelper.init()
 
 	.then(()=>{
 		if(DATABOX_DEV) {
-			proms = Config.localAppStoreSeedManifests.map((url)=>{
-				return new Promise(function(resolve, reject) {
-					request.get(url,(error,response,body)=>{
-						if(error) {
-							console.log("[seeding manifest] Failed to get manifest from" + url, error);
-						}
-						request.post({
-							uri: Config.storeUrl_dev + "/app/post",
-							method: "POST",
-							form: {"manifest": body}
-						}, (error,response,body) => {
+			var req = request.defaults({jar: true});
+			req.get(Config.storeUrl_dev,(error,response,body)=>{
+				if(error) {
+					console.log("[seeding manifest] get app store root to log in", error);
+				}
+				proms = Config.localAppStoreSeedManifests.map((url)=>{
+					return new Promise(function(resolve, reject) {
+						req.get(url,(error,response,body)=>{
 							if(error) {
-								console.log("[seeding manifest] Failed to POST manifest " + url, error);
-							} else {
-								console.log("[seeding manifest]" + url + " SUCCESS ");
-								resolve();
+								console.log("[seeding manifest] Failed to get manifest from" + url, error);
 							}
+							req.post({
+								uri: Config.storeUrl_dev + "/app/post",
+								method: "POST",
+								form: {"manifest": body}
+							}, (error,response,body) => {
+								if(error) {
+									console.log("[seeding manifest] Failed to POST manifest " + url, error);
+								} else {
+									console.log("[seeding manifest]" + url + " SUCCESS ",body);
+									resolve();
+								}
+							});
 						});
 					});
 				});
+				return Promise.all(proms);
 			});
-			return Promise.all(proms);
 		}
 	})
 

--- a/src/main.js
+++ b/src/main.js
@@ -12,12 +12,13 @@ var containerMangerUIServer = null;
 httpsHelper.init()
 	.then(cert => {
 		
-		//Put the CA pubic key into this processes env var so lib that work in containers also work in the CM
+		//Put the CA pubic key into this processes env var so libs that work in containers also work in the CM
 		process.env['CM_HTTPS_CA_ROOT_CERT'] = httpsHelper.getRootCert();
 
 		conman.setHttpsHelper(httpsHelper);
 		return conman.connect();
 	})
+	
 	.then(data => {
 		return conman.killAll(data);
 	})
@@ -51,7 +52,7 @@ httpsHelper.init()
 	
 	.then(info => {
 
-		//set env vars in this process so lib that work in containers also work in the CM 
+		//set env vars in this process so libs that work in containers also work in the CM 
 		process.env['DATABOX_ARBITER_ENDPOINT'] = 'https://' + info.name + ':' + info.port;
 		process.env['ARBITER_TOKEN'] = info.CM_KEY;
 		process.env['CM_KEY'] = info.CM_KEY;
@@ -59,7 +60,7 @@ httpsHelper.init()
 		//require here so env vars are set!
 		containerMangerUIServer = require('./server.js');
 
-		//set up the arbitor proxy
+		//set up the arbiter proxy
 		containerMangerUIServer.proxies[info.name] = info.name + ':' + info.port;
 		
 	})

--- a/src/main.js
+++ b/src/main.js
@@ -45,7 +45,7 @@ httpsHelper.init()
 	})
 	
 	.then(info => {
-		server.proxies[info.name] = 'localhost:' + info.port;
+		server.proxies[info.name] = info.name + ':' + info.port;
 
 		console.log("Starting UI Server!!");
 		return server.launch(Config.serverPort, conman, httpsHelper);
@@ -60,7 +60,7 @@ httpsHelper.init()
 	})
 
 	/*.then(info => {
-		server.proxies[info.name] = 'localhost:' + info.port;
+		server.proxies[info.name] = container.name+':' + info.port;
 
 		console.log('[databox-notification] Launching');
 		return conman.launchNotifications(httpsHelper);
@@ -73,9 +73,10 @@ httpsHelper.init()
 		return conman.restoreContainers(slas, httpsHelper);
 	})
 	.then(infos => {
+		console.log(infos);
 		for (var containers of infos) {
 			for (var container of containers) {
-				server.proxies[container.name] = 'localhost:' + container.port;
+				server.proxies[container.name] = container.name+':' + container.port;
 			}
 		}
 

--- a/src/server.js
+++ b/src/server.js
@@ -107,7 +107,6 @@ module.exports = {
 
 			conman.listContainers()
 				.then((containers) => {
-					console.log("[list-apps] containers ", containers);
 					for (var container of containers) {
 						var name = container.Names[0].substr(1);
 						names.push(name);
@@ -133,14 +132,12 @@ module.exports = {
 
 					//this request could be to a local or external registry add an agent that trust the CM ROOT cert just in case.
 					var options = {'url':"https://" + Config.registryUrl + "/v2/_catalog", 'method':'GET', 'agent':databoxAgent};
-					console.log("[list-apps] registery request",options);
 					request(options, (error, response, body) => {
 						if (error) {
 							res.json(error);
-							console.log("[list-apps] Error:: ",error);
 							return;
 						}
-						console.log("[list-apps] 1",body);
+
 						var repositories = JSON.parse(body).repositories;
 						var repocount = repositories.length;
 						repositories.map((repo) => {
@@ -155,10 +152,8 @@ module.exports = {
 
 									if (err) {
 										//do nothing
-										console.log("[list-apps] Error:: ",err);
 										return;
 									}
-									console.log("[list-apps] 2",body);
 
 									body = JSON.parse(data.body);
 									if (typeof body.error == 'undefined' || body.error != 23) {

--- a/src/server.js
+++ b/src/server.js
@@ -9,6 +9,25 @@ var url = require('url');
 
 var app = express();
 
+//
+// The  container manager can't always access or resolve containers by hostname.
+// This catches any resolve errors and points them at 127.0.0.1.
+// It it enables the  container manager UI to proxy over https to any docker container
+// along as it knows the docker assigned port that the service is running on. 
+// N.B this effects all dns lookups by the container manager!!
+var dns = require('dns');
+var origLookup = dns.lookup
+dns.lookup = function (domain, options, callback) {
+	origLookup(domain, options, function(err, address, family){
+		if(err) {
+			console.log("[DNS Intercepted] for " + domain + " returning 127.0.0.1");
+			callback(null, '127.0.0.1', 4);
+		} else {
+			callback(err, address, family);
+		}
+	});
+};
+
 module.exports = {
 	proxies: {},
 	app: app,
@@ -44,7 +63,7 @@ module.exports = {
 				}
 				else {
 					proxyURL = url.format({
-						protocol: req.protocol,
+						protocol: 'https',
 						host: replacement,
 						pathname: req.baseUrl + req.path.substring(firstPart.length + 1),
 						query: req.query
@@ -53,7 +72,14 @@ module.exports = {
 
 				console.log("[Proxy] " + req.method + ": " + req.url + " => " + proxyURL);
 				return req
-					.pipe(request(proxyURL))
+					.pipe(request({
+						uri:proxyURL,
+						'method':'GET', 
+						'agent':databoxAgent, 
+						'headers': {
+							'x-api-key': conman.arbiterKey
+						}
+					}))
 					.on('error', (e) => {
 						console.log('[Proxy] ERROR: ' + req.url + " " + e.message);
 					})

--- a/src/sethosts.js
+++ b/src/sethosts.js
@@ -10,7 +10,7 @@ var p = Promise.resolve();
 hosts.forEach((host, i) => {
 	p = p.then(() => new Promise((resolve, reject) => {
 		// TODO: Are we sure they map to those IPs on Linux? Should precede with docker inspect?
-		var ip = process.platform === 'linux' ? '172.17.0.' + (2 + i) : '127.0.0.1';
+		var ip = '127.0.0.1';
 		hostile.set(ip, host, (err) => err ? reject(err) : resolve());
 	}));
 });


### PR DESCRIPTION
The container manager uses a proxy to map requests to docker ephemeral ports on the localhost. This was broken due to the move to https.  The containers IP did not match the HTTPS certs host.  This approach would also not work with MacOS or Windows. 
 
To fix this the container managers DNS lookups are being intercepted. If a lookup fails to resolve they are mapped to 127.0.0.1. This fixes the HTTPS host mismatch and MacOS/Windows issues.