### PR TITLE
Check if the databox-cm container exists before delete it

### DIFF
--- a/DevStartInContiner.sh
+++ b/DevStartInContiner.sh
@@ -1,13 +1,9 @@
 #!/bin/bash
 
-docker kill databox-cm
-docker rm databox-cm
-
 if [ "$(docker ps -aq -f name=databox-cm)" ]; then
     docker stop databox-cm
     docker rm databox-cm
 fi
-
 
 docker create \
 	-v /var/run/docker.sock:/var/run/docker.sock \

--- a/DevStartInContiner.sh
+++ b/DevStartInContiner.sh
@@ -3,6 +3,12 @@
 docker kill databox-cm
 docker rm databox-cm
 
+if [ "$(docker ps -aq -f name=databox-cm)" ]; then
+    docker stop databox-cm
+    docker rm databox-cm
+fi
+
+
 docker create \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v `pwd`:/cm \

--- a/startInContiner.sh
+++ b/startInContiner.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
-docker kill databox-cm
-docker rm databox-cm
+if [ "$(docker ps -aq -f name=databox-cm)" ]; then
+    docker stop databox-cm
+    docker rm databox-cm
+fi
 
 docker run \
 	-v /var/run/docker.sock:/var/run/docker.sock \
@@ -9,7 +11,3 @@ docker run \
 	--label databox.type=container-manager \
 	-p 8989:8989 \
         -it toshdatabox/databox-cm
-
-
-
-


### PR DESCRIPTION
Two possible responses I get from using the original script: 
> Error response from daemon: Cannot kill container databox-cm: Container xxx is not running

and

> Error response from daemon: Cannot kill container databox-cm: No such container: databox-cm

So I think adding a condition check might not harm...