### PR TITLE
Pass hypercat item-metadata to apps at install time

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -732,18 +732,7 @@ let launchContainer = function (containerSLA) {
 
 				if ('datasources' in containerSLA) {
 					for (let datasource of containerSLA.datasources) {
-						let sensor = {
-							endpoint: datasource.endpoint,
-							sensor_id: datasource.sensor_id,
-						};
-						if (datasource.endpoint !== undefined) {
-							let index = datasource.endpoint.indexOf('/');
-							if (index != -1) {
-								sensor.hostname = sensor.endpoint.substr(0, index);
-								sensor.api_url = sensor.endpoint.substr(index);
-							}
-						}
-						config.Env.push("DATASOURCE_" + datasource.clientid + "=" + JSON.stringify(sensor));
+						config.Env.push("DATASOURCE_" + datasource.clientid + "=" + JSON.stringify(datasource.hypercat));
 					}
 				}
 

--- a/src/www/install.pug
+++ b/src/www/install.pug
@@ -70,6 +70,10 @@ html
 									}
 								}
 							}
+
+							//add the full hypercat item to pass to the app
+							sensor.hypercat = item;
+
 							console.log(sensor);
 							if (sensors == null) {
 								sensors = [sensor];
@@ -101,6 +105,7 @@ html
 								datasource.endpoint = sensor.endpoint;
 								datasource.sensor_id = sensor.id;
 								datasource.sensor = sensor.description + ", " + sensor.location;
+								datasource.hypercat = sensor.hypercat;
 								update();
 								return true;
 							}


### PR DESCRIPTION
The app gets passed information about the data sources they have been assigned at install time. This data is passed through an environment variable. 

Until now the data passed to the app was a custom JSON object encoded as a string. From now on the data passed will be the hypercat item relating to that data source. The hypercat item is extracted from the datastores /cat endpoint by the container manger.