### PR TITLE
databox-bridge first try: use docker bridge

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -303,6 +303,9 @@ var connectContainerPair = function (con0, con1) {
 			})
 			.catch((err) => {
 				console.log('[connectContainerPair]: ' + con0 + ' <> ' + con1);
+				if (dedicatedNet) {
+					dedicatedNet.remove();	
+				}
 				reject(err);
 			});
 	});
@@ -1016,6 +1019,13 @@ let launchContainer = function (containerSLA) {
 					}
 				}
 				resolve(launched);
+			})
+			.then(() => {
+				var connectDatasource = (source) => {
+					connectContainerPair(containerSLA.localContainerName, source.name);
+				};
+				
+				return Promise.all(containerSLA.datasources.map(connectDatasource));
 			})
 			.catch((err) => {
 				console.log("[" + name + "] ERROR Launching: " + err);

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -130,8 +130,8 @@ exports.initNetworks = function () {
 		dockerHelper.listNetworks()
 			.then(networks => {
 				var requiredNets = [
-					dockerHelper.getNetwork(networks, 'databox-driver-net'),
-					dockerHelper.getNetwork(networks, 'databox-app-net'),
+					//dockerHelper.getNetwork(networks, 'databox-driver-net'),
+					//dockerHelper.getNetwork(networks, 'databox-app-net'),
 					dockerHelper.getNetwork(networks, 'databox-cloud-net'),
 					dockerHelper.getNetwork(networks, 'databox-cm-arbiter-net')
 				];
@@ -392,12 +392,12 @@ exports.launchArbiter = function () {
 			.then((Arbiter) => {
 				return startContainer(Arbiter);
 			})
-			.then((Arbiter) => {
-				return dockerHelper.connectToNetwork(Arbiter, 'databox-driver-net');
-			})
-			.then((Arbiter) => {
-				return dockerHelper.connectToNetwork(Arbiter, 'databox-app-net');
-			})
+			// .then((Arbiter) => {
+			// 	return dockerHelper.connectToNetwork(Arbiter, 'databox-driver-net');
+			// })
+			// .then((Arbiter) => {
+			// 	return dockerHelper.connectToNetwork(Arbiter, 'databox-app-net');
+			// })
 			.then((Arbiter) => {
 				return dockerHelper.connectToNetwork(Arbiter, 'databox-cm-arbiter-net');
 			})
@@ -476,11 +476,11 @@ exports.launchLogStore = function () {
 			.then((logstore) => {
 				return startContainer(logstore);
 			})
-			.then((logstore) => {
-				var proms =  [ dockerHelper.connectToNetwork(logstore, 'databox-driver-net'),
-							   dockerHelper.connectToNetwork(logstore, 'databox-app-net')];
-				return Promise.all(proms);
-			})
+			// .then((logstore) => {
+			// 	var proms =  [ dockerHelper.connectToNetwork(logstore, 'databox-driver-net'),
+			// 				   dockerHelper.connectToNetwork(logstore, 'databox-app-net')];
+			// 	return Promise.all(proms);
+			// })
 			.then((logstores) => {
 				console.log('[' + name + '] Passing token to Arbiter');
 				var logstore = logstores[0];
@@ -535,9 +535,9 @@ exports.launchExportService = function () {
 			.then((exportService) => {
 				return startContainer(exportService);
 			})
-			.then((exportService) => {
-				return dockerHelper.connectToNetwork(exportService, 'databox-app-net');
-			})
+			// .then((exportService) => {
+			// 	return dockerHelper.connectToNetwork(exportService, 'databox-app-net');
+			// })
 			.then((exportService) => {
 				console.log('[' + name + '] Passing token to Arbiter');
 
@@ -576,12 +576,12 @@ exports.launchNotifications = function () {
 			.then((notifications) => {
 				return startContainer(notifications);
 			})
-			.then((notifications) => {
-				return dockerHelper.connectToNetwork(notifications, 'databox-driver-net');
-			})
-			.then((notifications) => {
-				return dockerHelper.connectToNetwork(notifications, 'databox-app-net');
-			})
+			// .then((notifications) => {
+			// 	return dockerHelper.connectToNetwork(notifications, 'databox-driver-net');
+			// })
+			// .then((notifications) => {
+			// 	return dockerHelper.connectToNetwork(notifications, 'databox-app-net');
+			// })
 			.then((notifications) => {
 				DATABOX_NOTIFICATIONS_ENDPOINT = 'http://' + notifications.ip + ':' + DATABOX_NOTIFICATIONS_PORT + '/notify';
 				resolve(notifications);

--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -271,6 +271,43 @@ exports.removeContainer = function (cont) {
 	});
 };
 
+var connectContainerPair = function (con0, con1) {
+
+	return new Promise((resolve, reject) => {
+		var dedicatedNet;
+
+		dockerHelper.listNetworks()
+			.then((nets) => {
+				let names = [con0 + '-' + con1, con1 + '-' + con0];
+				var existed = nets.filter((v) => { return names.includes(v); });
+
+				if (existed.length > 0) {
+					return docker.getNetwork(existed[0].Id);
+				} else {
+					let opts = {'Name': names[0], 'Driver': 'bridge'};
+					docker.createNetwork(opts);
+					return docker.getNetwork(opts.Name);
+				}
+			})
+			.then((net) => {
+				dedicatedNet = net;
+				let proms = [getContainer(con0), getContainer(con1)];
+				return Promise.all(proms);
+			})
+			.then((pair) => {
+				let proms = [
+					dockerHelper.connectToNetwork(pair[0], dedicatedNet.Id),
+					dockerHelper.connectToNetwork(pair[1], dedicatedNet.Id)
+				];
+				return Promise.all(proms);
+			})
+			.catch((err) => {
+				console.log('[connectContainerPair]: ' + con0 + ' <> ' + con1);
+				reject(err);
+			});
+	});
+};
+
 exports.launchLocalAppStore = function() {
 	return new Promise((resolve, reject) => {
 		var name = Config.localAppStoreName + ARCH;
@@ -481,6 +518,10 @@ exports.launchLogStore = function () {
 			// 				   dockerHelper.connectToNetwork(logstore, 'databox-app-net')];
 			// 	return Promise.all(proms);
 			// })
+			.then((logstore) => {
+				connectContainerPair(name, arbiterName);
+				return [logstore];
+			})
 			.then((logstores) => {
 				console.log('[' + name + '] Passing token to Arbiter');
 				var logstore = logstores[0];
@@ -538,6 +579,10 @@ exports.launchExportService = function () {
 			// .then((exportService) => {
 			// 	return dockerHelper.connectToNetwork(exportService, 'databox-app-net');
 			// })
+			.then((exportService) => {
+				connectContainerPair(name, arbiterName);
+				return exportService;
+			})
 			.then((exportService) => {
 				console.log('[' + name + '] Passing token to Arbiter');
 
@@ -856,11 +901,12 @@ let launchContainer = function (containerSLA) {
 						config.Env.push("DATASOURCE_" + datasource.clientid + "=" + JSON.stringify(datasource.hypercat));
 						if (datasource.enabled) {
  							// Grant read assess to enabled datasources
-							 proms.push(updateContainerPermissions({
+							proms.push(updateContainerPermissions({
 										name: containerSLA.name,
 										route: {target:containerSLA.host, path: containerSLA.api_url, method:'GET'}
 										//caveats: ""
 									}));
+							proms.push(connectContainerPair(containerSLA.name, containerSLA.host));
  						}
 					}
 				}
@@ -879,20 +925,23 @@ let launchContainer = function (containerSLA) {
 			.then((results) => {
 				return startContainer(results[results.length - 1]);
 			})
-			.then((container) => {
-				launched.push(container);
-				if (container.type == 'driver') {
-					return configureDriver(container);
-				} else if (container.type == 'store') {
-					return configureStore(container);
-				} else {
-					return configureApp(container);
-				}
-			})
+			// .then((container) => {
+			// 	launched.push(container);
+			// 	if (container.type == 'driver') {
+			// 		return configureDriver(container);
+			// 	} else if (container.type == 'store') {
+			// 		return configureStore(container);
+			// 	} else {
+			// 		return configureApp(container);
+			// 	}
+			// })
 			.then((container) => {
 				console.log('[' + containerSLA.localContainerName + '] Passing token to Arbiter');
 				var update = {name: containerSLA.localContainerName, key: arbiterToken, type: container.type};
 				return updateArbiter(update);
+			})
+			.then(() => {
+				connectContainerPair(containerSLA.localContainerName, arbiterName);
 			})
 			.then(() => {
 				//grant write access to requested stores
@@ -900,6 +949,10 @@ let launchContainer = function (containerSLA) {
 				for(store of dependentStores) {
 
 					if(containerSLA.localContainerName != store.name) {
+
+						connectContainerPair('databox-container-manager', store.name);
+						connectContainerPair(containerSLA.localContainerName, store.name);
+						connectContainerPair(store.name, DATABOX_LOGSTORE_NAME);
 
 						//Read /cat for CM
 						console.log('[Adding read permissions] for databox-container-manager on ' + store.name + '/cat');


### PR DESCRIPTION
This PR is <b>NOT</b> for the purpose of merging, at least for now. There surely are upcoming commits.

Just hope we could be synced up with this, as it touches some fondamental parts of the platform communication mechanism. Apart from in-box communication, hope I won't break some other things by accident.

Idea is simple
- By default, we don't have any network set up or connections. (*leave the databox-cm-arbiter-net and databox-cloud-net for now*)
- Based on `launchContainer`, we connect necessary paires together
- *LOGSTORE* and *EXPORT-SERVICE* are connected to *ARBITER* on start up

I'm not an experienced node programmer, if there is style problem or easily-spotted bugs, please point it to me. Thanks!