### PR TITLE
Limit internet connectivity

### DIFF
--- a/src/container-manager.js
+++ b/src/container-manager.js
@@ -146,10 +146,11 @@ exports.initNetworks = function () {
 		dockerHelper.listNetworks()
 			.then(networks => {
 				var requiredNets = [
-					dockerHelper.getNetwork(networks, 'databox-driver-net'),
+					dockerHelper.getNetwork(networks, 'databox-driver-net', true),
 					dockerHelper.getNetwork(networks, 'databox-app-net'),
 					dockerHelper.getNetwork(networks, 'databox-cloud-net'),
-					dockerHelper.getNetwork(networks, 'databox-cm-arbiter-net')
+					dockerHelper.getNetwork(networks, 'databox-cm-arbiter-net').
+					dockerHelper.getNetwork(networks, 'databox-external', true)
 				];
 
 				return Promise.all(requiredNets)
@@ -553,6 +554,9 @@ exports.launchExportService = function () {
 			})
 			.then((exportService) => {
 				return dockerHelper.connectToNetwork(exportService, 'databox-app-net');
+			})
+			.then((exportService) => {
+				return dockerHelper.connectToNetwork(exportService, 'databox-external');
 			})
 			.then((exportService) => {
 				console.log('[' + name + '] Passing token to Arbiter');

--- a/src/include/container-manager-docker-helper.js
+++ b/src/include/container-manager-docker-helper.js
@@ -39,9 +39,13 @@ exports.remove = function (id) {
   });
 }
 
-exports.createNetwork = function(name) {
+exports.createNetwork = function(name, external) {
   return new Promise( (resolve, reject) =>  {
-    docker.createNetwork({Name:name,Driver:'bridge'}, (err,data) => {
+    docker.createNetwork({
+        Name: name,
+        Driver: 'bridge',
+        Internal: !external
+      }, (err,data) => {
       if(err) {
         reject("[createNetwork] Can't list networks");
         return;
@@ -61,7 +65,7 @@ var listNetworks = function() {
 }
 exports.listNetworks = listNetworks;
 
-var getNetwork = function(networks, name) {
+var getNetwork = function(networks, name, external) {
   return new Promise( (resolve, reject) =>  {
     for(i in networks) {
           var net = networks[i];
@@ -72,7 +76,11 @@ var getNetwork = function(networks, name) {
           }
       }
 
-      docker.createNetwork({'Name': name, 'Driver': 'bridge'}, (err,data) => {
+      docker.createNetwork({
+          Name: name,
+          Driver: 'bridge',
+          Internal: !external
+        }, (err,data) => {
         if(err) reject("[getNetwork] Can't create networks")
         resolve(data);
       })


### PR DESCRIPTION
This PR does a few things:

- All networks have no external access by default
- `databox-driver-net` is an exception and has internet
- A new network, `databox-external` has internet
- The export service is connected to `databox-external`

Everything else is the same (old topology on this branch), so effectively, only apps can't talk to the outside, but driver still can. Worst case, if we don't use Docker network plugins, the bridge's function might end up coming down to managing iptables rules (https://docs.docker.com/engine/userguide/networking/default_network/container-communication/#communicating-to-the-outside-world) but let's see.

Pls let me know if I missed something.